### PR TITLE
feature/integrate upstream systemd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Created by .ignore support plugin (hsz.mobi)
 .idea/
+molecule/default/tests/__pycache__/

--- a/files/splunk.service
+++ b/files/splunk.service
@@ -1,17 +1,30 @@
- [Unit]
- Description=Splunk Enterprise 6.5
- After=network.target
- Wants=network.target
+[Unit]
+Description=Splunk Forwarder service
+Wants=network.target
+After=network.target
  
- [Service]
- Type=forking
- RemainAfterExit=False
- User=splunk
- Group=splunk
- LimitNOFILE=65536
- ExecStart=/opt/splunkforwarder/bin/splunk start --accept-license --answer-yes --no-prompt
- ExecStop=/opt/splunkforwarder/bin/splunk stop
- PIDFile=/opt/splunkforwarder/var/run/splunk/splunkd.pid
+[Service]
+Restart=always
+Type=simple
+ExecStart=/opt/splunkforwarder/bin/splunk _internal_launch_under_systemd --accept-license --no-prompt --answer-yes
+Delegate=true
+#Splunk defines successful exit codes other than 0 to indicate special exit scenarios which are
+#used by splunk operations like rolling-restart, offline etc.
+SuccessExitStatus=51 52
+RestartPreventExitStatus=51
+RestartForceExitStatus=52
+RemainAfterExit=no
+#On some systemd installations, systemd does not create cgroups for memory and cpu controller under system.slice
+#rather it runs process under root cgroups, we can force systemd to create cgroups under system.slice by specifying
+#MemoryLimit and CPUShares, please look at description below.
+#MemoryLimit=100G
+#CPUShares=1024
+#If you want to run splunk as root user, comment out the following five lines:
+PermissionsStartOnly=true
+User=splunk
+Group=splunk
+#ExecStartPost=/bin/bash -c "chown -R splunk:splunk /sys/fs/cgroup/cpu/system.slice/%n"
+#ExecStartPost=/bin/bash -c "chown -R splunk:splunk /sys/fs/cgroup/memory/system.slice/%n"
  
- [Install]
- WantedBy=multi-user.target
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Since 7.2.2, Splunk seems to officially support systemd and './bin/splunk enable boot-start -user splunk' will generate a unit file. I copied that unit file and commented unnecessary parameters.

Reference: https://docs.splunk.com/Documentation/Splunk/7.2.2/Admin/RunSplunkassystemdservice