### PR TITLE
Wait for hostname to be set on first boot

### DIFF
--- a/files/splunk.service
+++ b/files/splunk.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Splunk Forwarder service
-Wants=network.target
-After=network.target
+Wants=network-online.target
+After=network-online.target
  
 [Service]
 Restart=always


### PR DESCRIPTION
When this role is used via, say, packer to build an AMI on RHEL variants with systemd, splunkd ends up starting before systemd-hostname is run. When that happens, /etc/hostname already exists from the initial AMI, and splunk chooses an incorrect default-hostname. Waiting for network-online instead of network gives systemd-hostname time to set the hostname properly before splunk decides on its value.