### PR TITLE
Allow more descriptive definition of multiple input sources

### DIFF
--- a/templates/inputs.conf.j2
+++ b/templates/inputs.conf.j2
@@ -9,3 +9,16 @@ blacklist = \.bz2$
 ignoreOlderThan = 7d
 sourcetype = {{ splunk_forwarder_sourcetype }}
 {{ splunk_forwarder_logs }}
+
+
+{% if splunk_forwarder_items is mapping %}
+{% for name, entry in splunk_forwarder_items.items() %}
+[{{ name }}]
+{% if entry is mapping %}
+{% for key, value in entry.items() %}
+{{key}} = {{value}}
+{% endfor %}
+{% endif %}
+
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Instead of injecting through `splunk_forwarder_logs`
you can define the whole configuration as a hash.
For instance:
```yaml
splunk_forwarder_indexer: "platform-splunk.srv.trustly.tech:9997"
splunk_forwarder_index: "syslog"
splunk_forwarder_sourcetype: "syslog"
splunk_forwarder_logs:

splunk_forwarder_items:
  "tcp://localhost:10514":
    disabled: 0
    sourcetype: _json
    index: syslog
  "monitor:///var/log/syslog":
```
will generate:
```ini
[default]
index = syslog

blacklist = \.bz2$
ignoreOlderThan = 7d
sourcetype = syslog


[tcp://localhost:10514]
disabled = 0
sourcetype = _json
index = syslog

[monitor:///var/log/syslog]

```

This is a non breaking change to the original behaviour.