### PR TITLE
Install the acl package (required by ansible acl module)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,6 +81,11 @@
     backup: true
   tags: config_copy
 
+- name: Install the acl package
+  apt:
+    name: acl
+    update_cache: yes
+
 - name: Set logfile permissions
   acl:
     path: "{{ item }}"


### PR DESCRIPTION
The ansible acl plugin requires the debian acl package (setfacl) to be installed.