### PR TITLE
Do not set executable bit on service file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -127,6 +127,6 @@
     dest: /etc/systemd/system/splunkd.service
     owner: root
     group: root
-    mode: 0755
+    mode: 0644
   notify: Enable Splunk Forwarder
   when: ansible_service_mgr == 'systemd'


### PR DESCRIPTION
There is no need to mark systemd unit files as executable. In fact systemd complains about it with the following error:

"""
systemd[1]: Configuration file /etc/systemd/system/splunkd.service is marked executable. Please remove executable permission bits. Proceeding anyway.
"""