### PR TITLE
Default to empty list for splunk_forwarder_logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Within your playbook, you should set the following variables:
     splunk_forwarder_index:         # Set to the index that the forwarder should use i.e. "default"
     splunk_forwarder_sourcetype:    # Set the Source type i.e. "nginx"
 
-You also need to set what logs to forward.  You can do using yaml multiline:
+You also need to set what logs to forward. You can do so using a list:
 
     splunk_forwarder_logs:
       - /var/log/nginx/access.log

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,4 @@ splunk_forwarder_indexer: "splunk-indexer:9997"
 splunk_forwarder_index: "default"
 splunk_forwarder_sourcetype: "nginx"
 
-splunk_forwarder_logs:
-  - /var/log/nginx/access.log
-  - /var/log/nginx/error.log
+splunk_forwarder_logs: []


### PR DESCRIPTION
The `splunk_forwarder_logs` variable contained two default paths out of the box. When a user forgets to redefine this list it is likely to cause a failure in task "Set logfile permissions". Because the task is trying to modify permissions of files that might not exist, causing the following error:

```
failed: [myhostname] (item=/var/log/nginx/access.log) => changed=false 
  ansible_loop_var: item
  item: /var/log/nginx/access.log
  msg: Path not found or not accessible.
failed: [myhostname] (item=/var/log/nginx/error.log) => changed=false 
  ansible_loop_var: item
  item: /var/log/nginx/error.log
  msg: Path not found or not accessible.
```

I defined the `splunk_forwarder_logs` as an empty list in the defaults. While keeping the documentation and examples of this variable intact. For those who have redefined this list in their vars or playbook it will keep working as it was.
For new users it will now work without having to redefine that list from the start, and they still can do so later.