### PR TITLE
Ensure service runs as configured user:group

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -122,8 +122,8 @@
   with_items: "{{ splunk_forwarder_logs }}"
 
 - name: Upload Splunk Systemd Script
-  ansible.builtin.copy:
-    src: splunk.service
+  ansible.builtin.template:
+    src: splunkd.service.j2
     dest: /etc/systemd/system/splunkd.service
     owner: root
     group: root

--- a/templates/splunkd.service.j2
+++ b/templates/splunkd.service.j2
@@ -1,3 +1,6 @@
+#
+# {{ ansible_managed }}
+#
 [Unit]
 Description=Splunk Forwarder service
 Wants=network-online.target
@@ -21,10 +24,10 @@ RemainAfterExit=no
 #CPUShares=1024
 #If you want to run splunk as root user, comment out the following five lines:
 PermissionsStartOnly=true
-User=splunk
-Group=splunk
-#ExecStartPost=/bin/bash -c "chown -R splunk:splunk /sys/fs/cgroup/cpu/system.slice/%n"
-#ExecStartPost=/bin/bash -c "chown -R splunk:splunk /sys/fs/cgroup/memory/system.slice/%n"
+User={{ splunk_forwarder_user }}
+Group={{ splunk_forwarder_group }}
+#ExecStartPost=/bin/bash -c "chown -R {{ splunk_forwarder_user }}:{{ splunk_forwarder_group }} /sys/fs/cgroup/cpu/system.slice/%n"
+#ExecStartPost=/bin/bash -c "chown -R {{ splunk_forwarder_user }}:{{ splunk_forwarder_group }} /sys/fs/cgroup/memory/system.slice/%n"
  
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Configuring the Splunk user and group had no effect on the service.
This commit ensures the service unit follows the user and group setting.