### PR TITLE
adding configurable variable in inputs.conf

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ splunk_deb_checksum: "md5:817637baad2f485b54a4fecac9f671b3"
 splunk_arm_checksum: "md5:20657ba28e2dff77def3eab6d0f7d7a8"
 
 #for inputs.conf, blacklist regexp of excluded file to monitor
-splunk_forwarder_input_blacklist: "\.bz2$"
+splunk_forwarder_input_blacklist: '\.bz2$'
 
 # These may be removed at some point, but they are placeholders so I don't forget to set them
 splunk_forwarder_indexer: "splunk-indexer:9997"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,8 @@ splunk_rpm_checksum: "md5:4faa1073d4b4f5c2ca46a8e6d71d4737"
 splunk_deb_checksum: "md5:817637baad2f485b54a4fecac9f671b3"
 splunk_arm_checksum: "md5:20657ba28e2dff77def3eab6d0f7d7a8"
 
+#for inputs.conf, blacklist regexp of excluded file to monitor
+splunk_forwarder_input_blacklist: "\.bz2$"
 
 # These may be removed at some point, but they are placeholders so I don't forget to set them
 splunk_forwarder_indexer: "splunk-indexer:9997"

--- a/templates/inputs.conf.j2
+++ b/templates/inputs.conf.j2
@@ -5,7 +5,7 @@
 [default]
 index = {{ splunk_forwarder_index }}
 
-blacklist = \.bz2$
+blacklist = {{ splunk_forwarder_input_blacklist }}
 ignoreOlderThan = 7d
 sourcetype = {{ splunk_forwarder_sourcetype }}
 


### PR DESCRIPTION
in our use case logrotate file are ended by .gz and not .bz2.
So we are adding a variable to the template inputs.conf to be able to change the value of the configuration field "blacklist="
We are adding default value as \.bz2$ in default value file main.yml
