### PR TITLE
Make management of input and outputs optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ For most people, the default variables that are set should be fine, but there ar
      splunk_deb                                 # Default Deb Full URL
      splunk_deb_checksum                        # Default Deb Checksum
      splunk_rpm_checksum                        # Default RPM Checksum
+     splunk_forwarder_manage_inputs             # Bool whether to manage inputs.conf file, default: true
+     splunk_forwarder_manage_outputs            # Bool whether to manage outputs.conf file, default: true
 
 
 ### Playbook Variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,9 +17,12 @@ splunk_deb_checksum: "md5:817637baad2f485b54a4fecac9f671b3"
 splunk_arm_checksum: "md5:20657ba28e2dff77def3eab6d0f7d7a8"
 
 
-# These may be removed at some point, but they are placeholders so I don't forget to set them
-splunk_forwarder_indexer: "splunk-indexer:9997"
+# Configuration of inputs (inputs.conf)
+splunk_forwarder_manage_inputs: true
 splunk_forwarder_index: "default"
 splunk_forwarder_sourcetype: "nginx"
-
 splunk_forwarder_logs: []
+
+# Configuration of outputs (outputs.conf)
+splunk_forwarder_manage_outputs: true
+splunk_forwarder_indexer: "splunk-indexer:9997"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,6 +100,7 @@
     dest: /opt/splunkforwarder/etc/system/local/inputs.conf
     mode: 0664
     backup: true
+  when: splunk_forwarder_manage_inputs
   tags: config_copy
 
 - name: Copy outputs file
@@ -108,6 +109,7 @@
     dest: /opt/splunkforwarder/etc/system/local/outputs.conf
     mode: 0664
     backup: true
+  when: splunk_forwarder_manage_outputs
   tags: config_copy
 
 - name: Set logfile permissions


### PR DESCRIPTION
Allows to not create (or manage) `inputs.conf` and `output.conf`.
We do not use the `inputs.conf` and `outputs.conf`. So we do not create them from the get go.
Default behavior is unchanged. A user needs to explicitly set `splunk_forwarder_manage_inputs` and/or `splunk_forwarder_manage_outputs` to `false` to deactivate management of either of these files.