### PR TITLE
Allow for installation from repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,20 @@ Role Variables
 For most people, the default variables that are set should be fine, but there are use cases for changing them.  They are:
 
 
-     splunk_forwarder_user                      # Default User (splunk)
-     splunk_forwarder_group                     # Default Group (splunk)
-     splunk_forwarder_uid                       # Default UID (10011)
-     splunk_forwarder_gid                       # Default GID (10011)
-     splunk_release                             # Default Release Version (7.1.3)
-     splunk_url                                 # Default Download URL              
-     splunk_forwarder_rpm                       # Default Splunk RPM Name
-     splunk_forwarder_deb                       # Default Splunk Deb Name
-     splunk_rpm                                 # Default RPM Full URL
-     splunk_deb                                 # Default Deb Full URL
-     splunk_deb_checksum                        # Default Deb Checksum
-     splunk_rpm_checksum                        # Default RPM Checksum
+     splunk_forwarder_user                                  # Default User (splunk)
+     splunk_forwarder_group                                 # Default Group (splunk)
+     splunk_forwarder_uid                                   # Default UID (10011)
+     splunk_forwarder_gid                                   # Default GID (10011)
+     splunk_release                                         # Default Release Version (7.1.3)
+     splunk_url                                             # Default Download URL
+     splunk_forwarder_rpm                                   # Default Splunk RPM Name
+     splunk_forwarder_deb                                   # Default Splunk Deb Name
+     splunk_rpm                                             # Default RPM Full URL
+     splunk_deb                                             # Default Deb Full URL
+     splunk_deb_checksum                                    # Default Deb Checksum
+     splunk_rpm_checksum                                    # Default RPM Checksum
+     splunk_forwarder_install_with_package_manager          # set this to true to use the package manager, default: false
+     splunk_forwarder_packages                              # list of packages to be installed, default: [splunkforwarder]
 
 
 ### Playbook Variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,13 @@ splunk_forwarder_user: "splunk"
 splunk_forwarder_group: "splunk"
 splunk_forwarder_uid: "10011"
 splunk_forwarder_gid: "10011"
+
+# Install splunk forwarder using the package manager? Instead of direct download of .deb or .rpm
+splunk_forwarder_install_with_package_manager: false
+splunk_forwarder_packages:
+  - splunkforwarder
+
+# Variables that control installation of the splunk forwarder by direct downloaded .rpm or .deb
 splunk_release: "9.0.2"
 splunk_url: "https://download.splunk.com/products/universalforwarder/releases/{{ splunk_release }}/linux"
 # splunk_url: "https://d7wz6hmoaavd0.cloudfront.net/products/universalforwarder/releases/{{ splunk_release }}/linux"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ splunk_forwarder_gid: "10011"
 # Install splunk forwarder using the package manager? Instead of direct download of .deb or .rpm
 splunk_forwarder_install_with_package_manager: false
 splunk_forwarder_packages:
+  - curl
   - splunkforwarder
 
 # Variables that control installation of the splunk forwarder by direct downloaded .rpm or .deb

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   company: AustinCloudGuru
   license: MIT
   namespace: austincloudguru
-  min_ansible_version: "2.0"
+  min_ansible_version: "2.9"
   platforms:
     - name: Amazon
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,9 @@ galaxy_info:
     - name: Amazon
       versions:
         - all
+    - name: Debian
+      versions:
+        - bookworm
     - name: Ubuntu
       versions:
         - xenial

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -1,0 +1,13 @@
+---
+# Installation tasks for Debian Linux
+- name: Download the Splunk package (Debian/Ubuntu)
+  ansible.builtin.get_url:
+    url: "{{ splunk_deb }}"
+    dest: "/tmp/{{ splunk_forwarder_deb }}"
+    checksum: "{{ splunk_deb_checksum }}"
+    mode: 0664
+
+- name: Install Splunk (Debian/Ubuntu)
+  ansible.builtin.apt:
+    deb: "/tmp/{{ splunk_forwarder_deb }}"
+    state: present

--- a/tasks/install_from_package.yml
+++ b/tasks/install_from_package.yml
@@ -1,0 +1,7 @@
+---
+# Install splunk using distribution's package manager
+- name: Ensure Splunk Forwarder is installed using package manager
+  ansible.builtin.package:
+    name: "{{ splunk_forwarder_packages }}"
+    disable_gpg_check: true
+    state: present

--- a/tasks/install_from_package.yml
+++ b/tasks/install_from_package.yml
@@ -1,7 +1,15 @@
 ---
 # Install splunk using distribution's package manager
-- name: Ensure Splunk Forwarder is installed using package manager
-  ansible.builtin.package:
+
+- name: Ensure Splunk Forwarder using APT package manager
+  ansible.builtin.apt:
     name: "{{ splunk_forwarder_packages }}"
-    disable_gpg_check: "{% if ansible_facts.os_family == 'RedHat' %}true{% else %}omit{% endif %}"
     state: present
+  when: ansible_facts.os_family == 'Debian'
+
+- name: Ensure Splunk Forwarder using DNF package manager
+  ansible.builtin.dnf:
+    name: "{{ splunk_forwarder_packages }}"
+    disable_gpg_check: true
+    state: present
+  when: ansible_facts.os_family == 'RedHat'

--- a/tasks/install_from_package.yml
+++ b/tasks/install_from_package.yml
@@ -3,5 +3,5 @@
 - name: Ensure Splunk Forwarder is installed using package manager
   ansible.builtin.package:
     name: "{{ splunk_forwarder_packages }}"
-    disable_gpg_check: true
+    disable_gpg_check: "{% if ansible_facts.os_family == 'RedHat' %}true{% else %}omit{% endif %}"
     state: present

--- a/tasks/install_linux_aarch64.yml
+++ b/tasks/install_linux_aarch64.yml
@@ -1,0 +1,22 @@
+---
+# Installation tasks for Linux aarch64
+- name: Check Version Installed
+  ansible.builtin.shell: |
+      set -o pipefail
+      if [ -f /opt/splunkforwarder/bin/splunk ]; then
+        /opt/splunkforwarder/bin/splunk -version |tail -1 |cut -d ' ' -f 4
+      fi
+  args:
+    executable: /bin/bash
+  register: splunk_version_check
+  changed_when: splunk_version_check.stdout != splunk_release
+
+- name: Install the Splunk Package
+  ansible.builtin.unarchive:
+    src: "{{ splunk_arm }}"
+    dest: "/opt"
+    remote_src: true
+    owner: "{{ splunk_forwarder_user }}"
+    group: "{{ splunk_forwarder_group }}"
+    mode: 0755
+  when: splunk_version_check.stdout != splunk_release

--- a/tasks/install_redhat.yml
+++ b/tasks/install_redhat.yml
@@ -1,0 +1,21 @@
+---
+# Installation tasks for Red Hat Linux
+- name: Download the Splunk package (Enterprise Linux)
+  ansible.builtin.get_url:
+    url: "{{ splunk_rpm }}"
+    dest: "/tmp/{{ splunk_forwarder_rpm }}"
+    checksum: "{{ splunk_rpm_checksum }}"
+    mode: 0664
+
+- name: Install Splunk (python2 yum)
+  ansible.builtin.yum:
+    name: "/tmp/{{ splunk_forwarder_rpm }}"
+    state: present
+  when: ansible_facts.python.version.major | int < 3
+
+- name: Install Splunk (python3 dnf)
+  ansible.builtin.dnf:
+    name: "/tmp/{{ splunk_forwarder_rpm }}"
+    disable_gpg_check: true
+    state: present
+  when: ansible_facts.python.version.major | int >= 3

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,65 +15,15 @@
   tags: splunk_user
 
 - name: Install Splunk on Debian X86 Based Systems
-  block:
-    - name: Download the Splunk package (Debian/Ubuntu)
-      ansible.builtin.get_url:
-        url: "{{ splunk_deb }}"
-        dest: "/tmp/{{ splunk_forwarder_deb }}"
-        checksum: "{{ splunk_deb_checksum }}"
-        mode: 0664
-
-    - name: Install Splunk (Debian/Ubuntu)
-      ansible.builtin.apt:
-        deb: "/tmp/{{ splunk_forwarder_deb }}"
-        state: present
+  ansible.builtin.include_tasks: install_debian.yml
   when: ansible_os_family == "Debian" and ansible_architecture != "aarch64"
 
 - name: Install Splunk on Linux Based Arm Based Systems
-  block:
-    - name: Check Version Installed
-      ansible.builtin.shell: |
-          set -o pipefail
-          if [ -f /opt/splunkforwarder/bin/splunk ]; then
-            /opt/splunkforwarder/bin/splunk -version |tail -1 |cut -d ' ' -f 4
-          fi
-      args:
-        executable: /bin/bash
-      register: splunk_version_check
-      changed_when: splunk_version_check.stdout != splunk_release
-
-    - name: Install the Splunk Package
-      ansible.builtin.unarchive:
-        src: "{{ splunk_arm }}"
-        dest: "/opt"
-        remote_src: true
-        owner: "{{ splunk_forwarder_user }}"
-        group: "{{ splunk_forwarder_group }}"
-        mode: 0755
-      when: splunk_version_check.stdout != splunk_release
+  ansible.builtin.include_tasks: install_linux_aarch64.yml
   when: ansible_system == "Linux" and ansible_architecture == "aarch64"
 
 - name: Install Splunk on Enterprise Linux Based Systems
-  block:
-    - name: Download the Splunk package (Enterprise Linux)
-      ansible.builtin.get_url:
-        url: "{{ splunk_rpm }}"
-        dest: "/tmp/{{ splunk_forwarder_rpm }}"
-        checksum: "{{ splunk_rpm_checksum }}"
-        mode: 0664
-
-    - name: Install Splunk (python2 yum)
-      ansible.builtin.yum:
-        name: "/tmp/{{ splunk_forwarder_rpm }}"
-        state: present
-      when: ansible_facts.python.version.major | int < 3
-
-    - name: Install Splunk (python3 dnf)
-      ansible.builtin.dnf:
-        name: "/tmp/{{ splunk_forwarder_rpm }}"
-        disable_gpg_check: true
-        state: present
-      when: ansible_facts.python.version.major | int >= 3
+  ansible.builtin.include_tasks: install_redhat.yml
   when: ansible_os_family == "RedHat" and ansible_architecture != "aarch64"
 
 - name: Copy user seeds file

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,19 +21,19 @@
 - name: Install Splunk on Debian X86 Based Systems
   ansible.builtin.include_tasks: install_debian.yml
   when:
-    - not splunk_forwarder_install_with_package_manager
+    - not splunk_forwarder_install_with_package_manager | bool
     - ansible_os_family == "Debian" and ansible_architecture != "aarch64"
 
 - name: Install Splunk on Linux Based Arm Based Systems
   ansible.builtin.include_tasks: install_linux_aarch64.yml
   when:
-    - not splunk_forwarder_install_with_package_manager
+    - not splunk_forwarder_install_with_package_manager | bool
     - ansible_system == "Linux" and ansible_architecture == "aarch64"
 
 - name: Install Splunk on Enterprise Linux Based Systems
   ansible.builtin.include_tasks: install_redhat.yml
   when:
-    - not splunk_forwarder_install_with_package_manager
+    - not splunk_forwarder_install_with_package_manager | bool
     - ansible_os_family == "RedHat" and ansible_architecture != "aarch64"
 
 - name: Copy user seeds file

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,17 +14,27 @@
     state: present
   tags: splunk_user
 
+- name: Install Splunk using package manager
+  ansible.builtin.include_tasks: install_from_package.yml
+  when: splunk_forwarder_install_with_package_manager | bool
+
 - name: Install Splunk on Debian X86 Based Systems
   ansible.builtin.include_tasks: install_debian.yml
-  when: ansible_os_family == "Debian" and ansible_architecture != "aarch64"
+  when:
+    - not splunk_forwarder_install_with_package_manager
+    - ansible_os_family == "Debian" and ansible_architecture != "aarch64"
 
 - name: Install Splunk on Linux Based Arm Based Systems
   ansible.builtin.include_tasks: install_linux_aarch64.yml
-  when: ansible_system == "Linux" and ansible_architecture == "aarch64"
+  when:
+    - not splunk_forwarder_install_with_package_manager
+    - ansible_system == "Linux" and ansible_architecture == "aarch64"
 
 - name: Install Splunk on Enterprise Linux Based Systems
   ansible.builtin.include_tasks: install_redhat.yml
-  when: ansible_os_family == "RedHat" and ansible_architecture != "aarch64"
+  when:
+    - not splunk_forwarder_install_with_package_manager
+    - ansible_os_family == "RedHat" and ansible_architecture != "aarch64"
 
 - name: Copy user seeds file
   ansible.builtin.template:


### PR DESCRIPTION
Add functionality to install using a package repository.
Enabled only when the related boolean (` splunk_forwarder_install_with_package_manager`) is set to `true`. Default behavior of the role is unchanged (direct download of package files).

Tested on Red Hat 8, should work fine with Debian as well.
And I will test Debian later this month. If any issue arises, which I do not expect at all, I will fix it.

Resolves #13 